### PR TITLE
Quick-fix: changed constant `5.000000` on line 68 to `f`

### DIFF
--- a/R/netSimulator.R
+++ b/R/netSimulator.R
@@ -65,7 +65,7 @@ ggmGenerator <- function(
          if (is.list(input) && !is.null(input$thresholds)) {
         Data[,i] <- as.numeric(cut(Data[,i],sort(c(-Inf,input$thresholds[[i]],Inf))))
     } else {
-        Data[,i] <- as.numeric(cut(Data[,i],sort(c(-Inf,rnorm(5.000000-1),Inf))))
+        Data[,i] <- as.numeric(cut(Data[,i],sort(c(-Inf,rnorm(%f-1),Inf))))
     }  
   
     }',nLevels)


### PR DESCRIPTION
Hi Sacha,

The example I used in #22 was for a generated function with a constant 5.

I think that line 68 in `netSimulator.R` (i.e., Data[,i] <- as.numeric(cut(Data[,i],sort(c(-Inf,rnorm(5.000000-1),Inf))))) should be Data[,i] <- as.numeric(cut(Data[,i],sort(c(-Inf,rnorm(%f-1),Inf)))) (i.e., `f` instead of `5.000000`).

Sorry for the confusion and thanks for the quick reaction!