### PR TITLE
Added bridgeArgs argument

### DIFF
--- a/R/bootTable.R
+++ b/R/bootTable.R
@@ -7,9 +7,14 @@
 # node2
 # value
 
-statTable <- function(x, name, alpha = 1, computeCentrality = TRUE,statistics = c("edge","strength","closeness","betweenness"), directed = FALSE,
-                      communities=NULL,
-                      useCommunities="all", includeDiagonal = FALSE,...){
+statTable <- function(x, 
+                      name, 
+                      alpha = 1, 
+                      computeCentrality = TRUE,
+                      statistics = c("edge","strength","closeness","betweenness"), 
+                      directed = FALSE,
+                      bridgeArgs = list(),
+                      includeDiagonal = FALSE,...){
   # If list, table for every graph!
   if (is.list(x$graph)){
     Tables <- list()
@@ -123,21 +128,19 @@ statTable <- function(x, name, alpha = 1, computeCentrality = TRUE,statistics = 
       # names(EI) <- "expectedInfluence"
       bridgecen <- c("bridgeStrength", "bridgeCloseness", "bridgeBetweenness", "bridgeExpectedInfluence")
       if(any(bridgecen %in% statistics)){
-        if(is.null(communities)){
+        bridgeArgs <- c(list(network=Wmat), bridgeArgs)
+        if(is.null(bridgeArgs$communities)){
           warning("If bridge statistics are to be bootstrapped, the communities argument should be provided")
-          b <-  networktools::bridge(Wmat,...)
-          names(b) <- c(bridgecen, "bridgeExpectedInfluence2step","communities")
-        } else {
-          b <- networktools::bridge(Wmat, communities=communities, useCommunities=useCommunities)
-          names(b) <- c(bridgecen, "bridgeExpectedInfluence2step","communities")
-        }
+        } 
+        b <- do.call(networktools::bridge, args=bridgeArgs)
+        names(b) <- c(bridgecen, "bridgeExpectedInfluence2step","communities")
+        b$communities <- NULL
       } else {
         b <- NULL
       }
-      b$communities <- NULL
-      if(useCommunities[1] != "all"){
-        b <- lapply(b, function(cen){cen[communities %in% useCommunities]})
-        bridgeCentralityNames <- x[['labels']][communities %in% useCommunities]
+      if(!is.null(bridgeArgs$useCommunities) && bridgeArgs$useCommunities[1] != "all"){
+        b <- lapply(b, function(cen){cen[bridgeArgs$communities %in% bridgeArgs$useCommunities]})
+        bridgeCentralityNames <- x[['labels']][bridgeArgs$communities %in% bridgeArgs$useCommunities]
       } else {
         bridgeCentralityNames <- x[['labels']]
       }

--- a/R/bootnet.R
+++ b/R/bootnet.R
@@ -58,8 +58,9 @@ bootnet <- function(
   signed,
   directed,
   includeDiagonal = FALSE,
-  communities=NULL,
-  useCommunities="all",
+  communities,
+  useCommunities,
+  bridgeArgs=list(),
   library = .libPaths(),
   memorysaver = TRUE,
   # datatype = c("normal","graphicalVAR"), # Extracted from object or given
@@ -86,6 +87,13 @@ bootnet <- function(
     message(paste("Note: bootnet will store only the following statistics: ",paste0(statistics, collapse=", ")))
   }
   
+  # Check bridgeArgs:
+  if (!missing(communities)){
+    bridgeArgs$communities <- communities
+  }
+  if (!missing(useCommunities)){
+    bridgeArgs$useCommunities <- useCommunities
+  }
   
   type <- match.arg(type)
   # datatype <- match.arg(datatype)
@@ -715,7 +723,7 @@ bootnet <- function(
   if (verbose){
     message("Computing statistics...")
   }
-  statTableOrig <- statTable(sampleResult,  name = "sample", alpha = alpha, computeCentrality = computeCentrality,statistics=statistics, directed=directed, includeDiagonal=includeDiagonal, communities=communities, useCommunities=useCommunities)
+  statTableOrig <- statTable(sampleResult,  name = "sample", alpha = alpha, computeCentrality = computeCentrality,statistics=statistics, directed=directed, includeDiagonal=includeDiagonal, bridgeArgs=bridgeArgs)
   
   if (nCores == 1){
     if (verbose){
@@ -723,7 +731,7 @@ bootnet <- function(
     }
     statTableBoots <- vector("list", nBoots)
     for (b in seq_len(nBoots)){
-      statTableBoots[[b]] <- statTable(bootResults[[b]], name = paste("boot",b), alpha = alpha, computeCentrality = computeCentrality, statistics=statistics, directed=directed,  communities=communities, useCommunities=useCommunities,includeDiagonal=includeDiagonal)
+      statTableBoots[[b]] <- statTable(bootResults[[b]], name = paste("boot",b), alpha = alpha, computeCentrality = computeCentrality, statistics=statistics, directed=directed,  bridgeArgs=bridgeArgs, includeDiagonal=includeDiagonal)
       if (verbose){
         setTxtProgressBar(pb, b)
       }
@@ -736,7 +744,7 @@ bootnet <- function(
       # Set library:
       .libPaths(library)
       
-      statTable(bootResults[[b]], name = paste("boot",b), alpha = alpha, computeCentrality = computeCentrality, statistics=statistics, directed=directed, communities=communities, useCommunities=useCommunities,includeDiagonal=includeDiagonal)
+      statTable(bootResults[[b]], name = paste("boot",b), alpha = alpha, computeCentrality = computeCentrality, statistics=statistics, directed=directed, bridgeArgs=bridgeArgs, includeDiagonal=includeDiagonal)
     }, cl = cl)
     # Stop the cluster:
     stopCluster(cl)


### PR DESCRIPTION
The bridgeArgs argument allows users to pass any argument through to networktools::bridge() in list format. For example:

bootnet(..., bridgeArgs=list(communities=foo, nodes=bar, normalize=TRUE))

The communities and useCommunities arguments are preserved for backwards compatibility. 