### PR TITLE
added eigenvector centrality to bootnet

### DIFF
--- a/R/bootTable.R
+++ b/R/bootTable.R
@@ -34,7 +34,7 @@ statTable <- function(x,
   # Change first letter of statistics to lowercase:
   substr(statistics,0,1) <- tolower(substr(statistics,0,1))
   validStatistics <-  c("intercept","edge","length","distance","closeness","betweenness","strength","expectedInfluence",
-                        "outStrength","outExpectedInfluence","inStrength","inExpectedInfluence","rspbc","hybrid",
+                        "outStrength","outExpectedInfluence","inStrength","inExpectedInfluence","rspbc","hybrid", "eigenvector",
                         "bridgeStrength", "bridgeCloseness", "bridgeBetweenness",
                         "bridgeExpectedInfluence")
   if (!all(statistics %in% validStatistics)){
@@ -273,6 +273,33 @@ statTable <- function(x,
         tables$rspbc <- dplyr::tbl_df(data.frame(
           name = name,
           type = "hybrid",
+          node1 = x[['labels']],
+          node2 = '',
+          value = NA,
+          stringsAsFactors = FALSE
+        ))
+      }
+      
+    }
+    
+    # eigenvector:
+    if ("eigenvector" %in% statistics){
+      
+      tryeigenvector <- try({
+        tables$eigenvector <- dplyr::tbl_df(data.frame(
+          name = name,
+          type = "eigenvector",
+          node1 = x[['labels']],
+          node2 = '',
+          value = as.vector(NetworkToolbox::eigenvector(Wmat)),
+          stringsAsFactors = FALSE
+        ))
+      })
+      
+      if (is(tryeigenvector,"try-error")){
+        tables$eigenvector <- dplyr::tbl_df(data.frame(
+          name = name,
+          type = "eigenvector",
           node1 = x[['labels']],
           node2 = '',
           value = NA,

--- a/R/bootnet.R
+++ b/R/bootnet.R
@@ -80,7 +80,7 @@ bootnet <- function(
   # Check if statistics is all:
   if (any(statistics=="all")){
     statistics <- c("intercept","edge","length","distance","closeness","betweenness","strength","expectedInfluence",
-                    "outStrength","outExpectedInfluence","inStrength","inExpectedInfluence","rspbc","hybrid",
+                    "outStrength","outExpectedInfluence","inStrength","inExpectedInfluence","rspbc","hybrid", "eigenvector",
                     "bridgeStrength", "bridgeCloseness", "bridgeBetweenness",
                     "bridgeExpectedInfluence")
   } else {

--- a/man/bootnet.Rd
+++ b/man/bootnet.Rd
@@ -57,6 +57,7 @@ Vector indicating which statistics to store. Options are:
 \item{\code{"bridgeBetweenness"}}{Bridge-betweenness (see \code{\link[networktools]{bridge}})}
 \item{\code{"rspbc"}}{Randomized shortest paths betweenness centrality (see \code{\link[NetworkToolbox]{rspbc}})}
 \item{\code{"hybrid"}}{Hybrid centrality (see \code{\link[NetworkToolbox]{hybrid}})}
+\item{\code{"eigenvector"}}{Eigenvector centrality (see \code{\link[NetworkToolbox]{eigenvector}})}
 }
 Can contain \code{"edge"}, \code{"strength"}, \code{"closeness"}, \code{"betweenness"}, \code{"length"}, \code{"distance"}, \code{"expectedInfluence"}, \code{"inExpectedInfluence"}, \code{"outExpectedInfluence"}. By default, length and distance are not stored.
 }


### PR DESCRIPTION
o eigenvector added to bootnet and its documentation

o ran one test, which worked (kept `try` error check from other NetworkToolbox centralities):

```
# Run bootnet
test <- bootnet(data = NetworkToolbox::neoOpen, default = "EBICglasso",
                          model = "GGM", nCores = 6, statistics = "eigenvector", type = "case")

# Get results table
test$bootTable

# Check stability
corStability(test)

# Plot stability
plot(test, statistics = "eigenvector")
```